### PR TITLE
Patch supervisord

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,26 +6,26 @@ ENV DEBIAN_FRONTEND noninteractive
 
 # update repos/ppas...
 RUN apt-get update 
-RUN apt-get install -y python-software-properties software-properties-common
+RUN apt-get install -y python-software-properties software-properties-common 
 RUN apt-add-repository -y ppa:x2go/stable
 RUN apt-get update 
 
 # install core packages
-RUN apt-get install -y python-pip git openssh-server vim emacs screen tmux locate
-RUN apt-get install -y python-matplotlib python-scipy python-numpy
-RUN apt-get install -y python-sklearn python-sklearn-doc python-skimage python-skimage-doc python-scikits-learn python-scikits.statsmodels
+RUN apt-get update &&  \
+    apt-get install -y python-pip git openssh-server vim emacs screen tmux locate \
+    	    	       python-matplotlib python-scipy python-numpy \
+                       python-sklearn python-sklearn-doc python-skimage \
+                       python-skimage-doc python-scikits-learn python-scikits.statsmodels \
+		       python-opencv gimp \
+		       firefox evince audacity meld \
+		       xfwm4 xfce4 x2goserver x2goserver-xsession \
+		       autotools-dev autoconf sudo wireshark gdb
+		       
 
 # Set up remove login info
 RUN mkdir /var/run/sshd
 RUN echo 'root:radioml' | chpasswd
 RUN sed -i 's/PermitRootLogin without-password/PermitRootLogin yes/' /etc/ssh/sshd_config
-
-# somewhat more graphical packages..
-RUN apt-get install -y python-opencv gimp 
-RUN apt-get install -y firefox evince audacity meld
-
-# set up remove visual login packages ...
-RUN apt-get install -y xfwm4 xfce4 x2goserver x2goserver-xsession
 
 # install python packages
 RUN pip install --upgrade pip
@@ -36,7 +36,6 @@ RUN pip install --upgrade git+https://github.com/fchollet/keras.git
 RUN pip install --upgrade seaborn tqdm
 
 # set up gnuradio and related tools
-RUN apt-get install -y autotools-dev autoconf sudo wireshark gdb
 RUN pip install --upgrade git+https://github.com/gnuradio/pybombs.git
 RUN mkdir /gr/
 RUN cd /gr/ && pybombs prefix init .
@@ -65,3 +64,11 @@ RUN mkdir /root/src/notebooks/
 # copy in some helpful files / set up env on login
 COPY .vimrc /root/
 RUN echo "source /gr/setup_env.sh" >> /root/.bashrc
+
+COPY imagefiles-supervisord /etc/supervisor/conf.d/supervisord.conf
+
+RUN mkdir -p /root/.jupyter
+COPY imagefiles-jupyter /root/.jupyter
+
+EXPOSE 22 8888
+CMD ["/usr/bin/supervisord"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,19 @@ RUN mkdir /var/run/sshd
 RUN echo 'root:radioml' | chpasswd
 RUN sed -i 's/PermitRootLogin without-password/PermitRootLogin yes/' /etc/ssh/sshd_config
 
+#
+# Add interactive user for x2go
+#
+RUN adduser --gecos "X2Go User" --disabled-password x2go
+RUN echo "x2go:x2go" | chpasswd
+RUN mkdir -p /home/x2go/.jupyter /home/x2go/mnt
+COPY imagefiles-jupyter /home/x2go/.jupyter
+COPY imagefiles-sudo /etc/sudoers.d
+COPY .vimrc /home/x2go/
+RUN echo "source /gr/setup_env.sh" >> /home/x2go/.bashrc
+
+VOLUME /home/x2go/mnt
+
 # install python packages
 RUN pip install --upgrade pip
 RUN pip install --upgrade ipython[all]
@@ -44,32 +57,31 @@ RUN cd /gr/ && pybombs recipes add gr-etcetera git+https://github.com/gnuradio/g
 RUN cd /gr/ && pybombs install gnuradio gr-burst gr-pyqt gr-pcap gr-mapper gr-analysis 
 
 # check out sources for reference
-RUN /bin/ln -s /gr/src/ /root/src
-RUN cd /root/src/ && git clone https://github.com/Theano/Theano.git
-RUN cd /root/src/ && git clone https://github.com/tensorflow/tensorflow.git
-RUN cd /root/src/ && git clone https://github.com/fchollet/keras.git
+RUN /bin/ln -s /gr/src/ /home/x2go/src
+RUN cd /home/x2go/src/ && git clone https://github.com/Theano/Theano.git
+RUN cd /home/x2go/src/ && git clone https://github.com/tensorflow/tensorflow.git
+RUN cd /home/x2go/src/ && git clone https://github.com/fchollet/keras.git
 
 # Build PyOpenPNL and Gym deps
 RUN pip install networkx
 RUN apt-get install -y python-numpy python-dev cmake zlib1g-dev libjpeg-dev xvfb libav-tools xorg-dev python-opengl libboost-all-dev libsdl2-dev swig pypy-dev
-RUN cd /root/src/ && git clone https://github.com/PyOpenPNL/OpenPNL.git && cd OpenPNL && ./autogen.sh &&  ./configure CFLAGS='-g -O2 -fpermissive -w' CXXFLAGS='-g -O2 -fpermissive -w' && make -j4 && make install
-RUN cd /root/src/ && git clone https://github.com/PyOpenPNL/PyOpenPNL.git && cd PyOpenPNL && python setup.py build && python setup.py install
-RUN cd /root/src/ && git clone https://github.com/osh/kerlym.git && cd kerlym && python setup.py build && python setup.py install
+RUN cd /home/x2go/src/ && git clone https://github.com/PyOpenPNL/OpenPNL.git && cd OpenPNL && ./autogen.sh &&  ./configure CFLAGS='-g -O2 -fpermissive -w' CXXFLAGS='-g -O2 -fpermissive -w' && make -j4 && make install
+RUN cd /home/x2go/src/ && git clone https://github.com/PyOpenPNL/PyOpenPNL.git && cd PyOpenPNL && python setup.py build && python setup.py install
+RUN cd /home/x2go/src/ && git clone https://github.com/osh/kerlym.git && cd kerlym && python setup.py build && python setup.py install
 
 # set up OpenAI Gym
-RUN cd /root/src/ && git clone https://github.com/openai/gym.git && cd gym && pip install -e .
+RUN cd /home/x2go/src/ && git clone https://github.com/openai/gym.git && cd gym && pip install -e .
 RUN pip install gym[atari] pachi_py
-RUN mkdir /root/src/notebooks/
+RUN mkdir /home/x2go/src/notebooks/
 
+
+WORKDIR /home/x2go
 # copy in some helpful files / set up env on login
-COPY .vimrc /root/
-RUN echo "source /gr/setup_env.sh" >> /root/.bashrc
+COPY .vimrc /home/x2go/
+RUN echo "source /gr/setup_env.sh" >> /home/x2go/.bashrc
 
 RUN apt-get install -y supervisor
 COPY imagefiles-supervisord /etc/supervisor/conf.d
-
-RUN mkdir -p /root/.jupyter
-COPY imagefiles-jupyter /root/.jupyter
 
 RUN sed -i 's/PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
 
@@ -79,6 +91,7 @@ RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so
 ENV NOTVISIBLE "in users profile"
 RUN echo "export VISIBLE=now" >> /etc/profile
 
-WORKDIR /root
+RUN chown -R x2go /home/x2go
+
 EXPOSE 22 8888
 CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/supervisord.conf", "-n"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,6 +65,3 @@ RUN mkdir /root/src/notebooks/
 # copy in some helpful files / set up env on login
 COPY .vimrc /root/
 RUN echo "source /gr/setup_env.sh" >> /root/.bashrc
-
-
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,10 +66,19 @@ COPY .vimrc /root/
 RUN echo "source /gr/setup_env.sh" >> /root/.bashrc
 
 RUN apt-get install -y supervisor
-COPY imagefiles-supervisord /etc/supervisor/conf.d/supervisord.conf
+COPY imagefiles-supervisord /etc/supervisor/conf.d
 
 RUN mkdir -p /root/.jupyter
 COPY imagefiles-jupyter /root/.jupyter
 
+RUN sed -i 's/PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
+
+# SSH login fix. Otherwise user is kicked off after login
+RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd
+
+ENV NOTVISIBLE "in users profile"
+RUN echo "export VISIBLE=now" >> /etc/profile
+
+WORKDIR /root
 EXPOSE 22 8888
 CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/supervisord.conf", "-n"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,10 +65,11 @@ RUN mkdir /root/src/notebooks/
 COPY .vimrc /root/
 RUN echo "source /gr/setup_env.sh" >> /root/.bashrc
 
+RUN apt-get install -y supervisor
 COPY imagefiles-supervisord /etc/supervisor/conf.d/supervisord.conf
 
 RUN mkdir -p /root/.jupyter
 COPY imagefiles-jupyter /root/.jupyter
 
 EXPOSE 22 8888
-CMD ["/usr/bin/supervisord"]
+CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/supervisord.conf", "-n"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+build-radioml:
+	docker build --rm -t radioml .

--- a/imagefiles-jupyter/jupyter_notebook_config.py
+++ b/imagefiles-jupyter/jupyter_notebook_config.py
@@ -1,0 +1,3 @@
+## The port the notebook server will listen on.
+c.NotebookApp.ip = "*"
+c.NotebookApp.port = 8888

--- a/imagefiles-sudo/x2go
+++ b/imagefiles-sudo/x2go
@@ -1,0 +1,1 @@
+x2go ALL=(ALL) NOPASSWD:ALL

--- a/imagefiles-supervisord/jupyter.conf
+++ b/imagefiles-supervisord/jupyter.conf
@@ -1,2 +1,5 @@
 [program:jupyter]
+user=x2go
+directory=/home/x2go
+environment=HOME="/home/x2go",USER="x2go",jupyter_config="/home/x2go/.jupyter"
 command=jupyter notebook

--- a/imagefiles-supervisord/jupyter.conf
+++ b/imagefiles-supervisord/jupyter.conf
@@ -1,0 +1,2 @@
+[program:jupyter]
+command=jupyter notebook

--- a/imagefiles-supervisord/sshd.conf
+++ b/imagefiles-supervisord/sshd.conf
@@ -1,0 +1,2 @@
+[program:sshd]
+command=/usr/sbin/sshd -D

--- a/imagefiles-supervisord/supervisord.conf
+++ b/imagefiles-supervisord/supervisord.conf
@@ -1,0 +1,5 @@
+[supervisord]
+nodaemon=true
+
+[program:sshd]
+command=/usr/sbin/sshd -D

--- a/imagefiles-supervisord/supervisord.conf
+++ b/imagefiles-supervisord/supervisord.conf
@@ -3,3 +3,6 @@ nodaemon=true
 
 [program:sshd]
 command=/usr/sbin/sshd -D
+
+[program:jupyter]
+command=jupyter notebook

--- a/imagefiles-supervisord/supervisord.conf
+++ b/imagefiles-supervisord/supervisord.conf
@@ -1,8 +1,2 @@
 [supervisord]
 nodaemon=true
-
-[program:sshd]
-command=/usr/sbin/sshd -D
-
-[program:jupyter]
-command=jupyter notebook


### PR DESCRIPTION
This PR provides functionality as described in the README. With the original dockerfile, the container would exit immediately because there wasn't a CMD. This adds supervisord to run both an sshd and jupyter process. The dockerfile is modified to create a user 'x2go' which allows the x2go service to work correctly -- for reasons I couldn't determine but could work around, switching to a non-root account allowed x2go to work. The jupyter process runs as user 'x2go' and runs from the /home/x2go directory (requiring a little diddling of the environment in the supervisord file). The x2go user is also enabled for password-less sudo.

At the end of the day, this satisfies the goals of your dockerfile and this is what our spectrum challenge team will be using as a dev environment. I didn't update the docs because I suspect 'x2go' is an uninspiring user name.
